### PR TITLE
Add Dockerfile and mechanism to use distrobox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM commonlispbr/roswell
+RUN apt update && apt install libsdl1.2-dev libsdl-ttf2.0-dev libsdl-gfx1.2-dev libsdl-mixer1.2-dev -y
+WORKDIR /app
+COPY . .
+RUN /app/build.ros

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+VERSION := latest
+IMAGE := commonlispbr/starwar:$(VERSION)
+
 build:
 	rm -rf release/
 	mkdir -p release
@@ -8,3 +11,12 @@ build:
 	mv lib/ release/
 	cp StarWar.desktop release/
 	sed -i 's/starwar.lisp/starwar-linux/g' release/StarWar.desktop
+
+docker-build:
+	docker build -t $(IMAGE) .
+
+docker-push: docker-build
+	docker push $(IMAGE)
+
+distrobox-export:
+	distrobox-export --app starwar --bin /app/starwar-linux --export-path ~/.local/bin

--- a/build.ros
+++ b/build.ros
@@ -1,0 +1,23 @@
+#!/bin/sh
+#|-*- mode:lisp -*-|#
+#|
+exec ros -Q -- $0 "$@"
+|#
+(progn ;;init forms
+  (ros:ensure-asdf)
+  (pushnew (uiop/os:getcwd) asdf:*central-registry*)
+  (ql:register-local-projects)
+  (ql:quickload :starwar)
+  )
+
+(defpackage :ros.script.starwar.3875017217
+  (:use :cl))
+
+(in-package :ros.script.starwar.3875017217)
+
+(defun main (&rest argv)
+  (declare (ignorable argv))
+  (starwar:make-binary)
+  (delete-file (probe-file "system-index.txt"))
+  )
+;;; vim: set ft=lisp lisp:


### PR DESCRIPTION
If you have a functional installation of distrobox, you can test this
game by calling this command:

     distrobox-ephemeral --image commonlispbr/starwar -- /app/starwar-linux

You can export the game by calling:

    distrobox create --name starwar --image commonlispbr/starwar
    distrobox enter starwar
    cd /app && make distrobox-export

The game will be available at ~/.local/bin/starwar-linux. You can call
at your host system.

It would be cool to make .desktop file work properly with distrobox to
show the game at host system menu.